### PR TITLE
feat(studio): unify OAuth and credential connection flow

### DIFF
--- a/studio/web/src/app/dashboard/agents/[id]/page.tsx
+++ b/studio/web/src/app/dashboard/agents/[id]/page.tsx
@@ -129,6 +129,7 @@ function AgentDetailPageContent({
   const [registerOAuthOpen, setRegisterOAuthOpen] = useState(false);
   const [selectedIntegration, setSelectedIntegration] = useState<IntegrationSummary | null>(null);
   const [selectedExisting, setSelectedExisting] = useState<Credential | null>(null);
+  const [oauthEditReturnTarget, setOauthEditReturnTarget] = useState<"none" | "override">("none");
 
   // Diff state (from pipeline SSE)
   const [lastDiff, setLastDiff] = useState<string | null>(null);
@@ -325,25 +326,8 @@ function AgentDetailPageContent({
 
   // ── Credential Modal ──────────────────────────────────────────
 
-   const startOAuthConnect = useCallback(async (provider: string): Promise<boolean> => {
-     try {
-       const { authorize_url } = await api.oauth.authorize(provider, id);
-       const popup = window.open(authorize_url, "oauth_authorize", "width=500,height=700,noopener=0");
-       if (!popup) return false;
-       return true;
-     } catch {
-       return false;
-     }
-   }, [id]);
-
    const openCredentialModal = async (card: ActionCard) => {
-     // OAuth flow: open popup → user authorizes → popup closes → refresh credentials
-     if (card.type === "oauth_redirect") {
-       await startOAuthConnect(card.skill);
-       return;
-     }
-
-     // Use standardized dialog for manual credential flow
+     // Unified: always open the shared IntegrationConnectionDialog
      try {
        const [integrations, apps] = await Promise.all([
          api.integrations.list(),
@@ -358,16 +342,17 @@ function AgentDetailPageContent({
        setSelectedExisting(existing);
        setOverrideDialogOpen(true);
      } catch {
-       // ignore
+       toast.error("Failed to load integration details. Please try again.");
      }
    };
 
-   const refreshOAuthApps = useCallback(async () => {
+   const refreshOAuthApps = useCallback(async (): Promise<OAuthApp[] | null> => {
      try {
        const apps = await api.oauthApps.list();
        setOAuthApps(apps);
+       return apps;
      } catch {
-       // ignore
+       return null;
      }
    }, []);
 
@@ -987,16 +972,31 @@ function AgentDetailPageContent({
           // popup is opened; on oauth_complete message we refresh credentials
         }}
         onConfigureOAuthApp={() => {
+          setOauthEditReturnTarget("override");
           setRegisterOAuthOpen(true);
         }}
       />
 
       <OAuthAppRegistrationDialog
         open={registerOAuthOpen}
-        onOpenChange={setRegisterOAuthOpen}
+        onOpenChange={(open) => {
+          setRegisterOAuthOpen(open);
+          if (!open) setOauthEditReturnTarget("none");
+        }}
         integration={selectedIntegration}
         existing={existingOAuthApp}
-        onSaved={() => void refreshOAuthApps()}
+        onSaved={async () => {
+          const apps = await refreshOAuthApps();
+          if (!apps) {
+            toast.error("Failed to refresh OAuth apps.");
+            return;
+          }
+          if (oauthEditReturnTarget === "override") {
+            setRegisterOAuthOpen(false);
+            setOauthEditReturnTarget("none");
+            setOverrideDialogOpen(true);
+          }
+        }}
       />
 
       <Dialog

--- a/studio/web/src/app/dashboard/integrations/page.tsx
+++ b/studio/web/src/app/dashboard/integrations/page.tsx
@@ -126,7 +126,7 @@ function IntegrationCard({
                       </button>
                     </TooltipTrigger>
                     <TooltipContent side="top" sideOffset={6}>
-                      {!oauthReady ? "OAuth app not configured. Click to set up." : "Click to update OAuth App"}
+                      {!oauthReady ? "Configure OAuth App" : "Update OAuth App"}
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
@@ -205,6 +205,7 @@ export default function IntegrationsPage() {
   const [selectedIntegration, setSelectedIntegration] = useState<IntegrationSummary | null>(null);
   const [deleteDefaultTarget, setDeleteDefaultTarget] = useState<string | null>(null);
   const [deletingDefault, setDeletingDefault] = useState(false);
+  const [oauthEditReturnTarget, setOauthEditReturnTarget] = useState<"none" | "connect">("none");
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -237,12 +238,13 @@ export default function IntegrationsPage() {
     setByokSupport(next);
   }, [integrations]);
 
-  const refreshOAuthApps = useCallback(async () => {
+  const refreshOAuthApps = useCallback(async (): Promise<OAuthApp[] | null> => {
     try {
       const apps = await api.oauthApps.list();
       setOAuthApps(apps);
+      return apps;
     } catch {
-      // ignore
+      return null;
     }
   }, []);
 
@@ -359,6 +361,7 @@ export default function IntegrationsPage() {
                 onDisconnect={() => setDeleteDefaultTarget(integration.name)}
                 onConfigureOAuth={() => {
                   setSelectedIntegration(integration);
+                  setOauthEditReturnTarget("none");
                   setRegisterOpen(true);
                 }}
               />
@@ -369,10 +372,24 @@ export default function IntegrationsPage() {
 
       <OAuthAppRegistrationDialog
         open={registerOpen}
-        onOpenChange={setRegisterOpen}
+        onOpenChange={(open) => {
+          setRegisterOpen(open);
+          if (!open) setOauthEditReturnTarget("none");
+        }}
         integration={selectedIntegration}
         existing={existingOAuthApp}
-        onSaved={() => void refreshOAuthApps()}
+        onSaved={async () => {
+          const apps = await refreshOAuthApps();
+          if (!apps) {
+            toast.error("Failed to refresh OAuth apps.");
+            return;
+          }
+          if (oauthEditReturnTarget === "connect") {
+            setRegisterOpen(false);
+            setOauthEditReturnTarget("none");
+            setConnectOpen(true);
+          }
+        }}
       />
 
       <IntegrationConnectionDialog
@@ -391,6 +408,7 @@ export default function IntegrationsPage() {
           // popup is opened; postMessage listener refreshes connection list on completion
         }}
         onConfigureOAuthApp={() => {
+          setOauthEditReturnTarget("connect");
           setRegisterOpen(true);
         }}
       />

--- a/studio/web/src/components/agent/chat-panel.tsx
+++ b/studio/web/src/components/agent/chat-panel.tsx
@@ -399,14 +399,6 @@ export default function ChatPanel({
                                 ? <><HugeiconsIcon icon={CheckmarkCircle02Icon} className="size-3.5" /> Saved</>
                                 : credentials.find((c) => c.provider === card.skill) ? "Update" : "Connect"}
                             </Button>
-                            {card.type === "oauth_redirect" && !recentlySavedSkill && (
-                              <button
-                                onClick={() => onOpenCredentialModal({ ...card, type: "connect_credential" })}
-                                className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline transition-colors"
-                              >
-                                Use API key instead
-                              </button>
-                            )}
                           </div>
                         </div>
                       </div>

--- a/studio/web/src/components/integrations/connection-dialogs.tsx
+++ b/studio/web/src/components/integrations/connection-dialogs.tsx
@@ -53,7 +53,7 @@ export interface OAuthAppRegistrationDialogProps {
   onOpenChange: (open: boolean) => void;
   integration: IntegrationSummary | null;
   existing: OAuthApp | null;
-  onSaved?: () => void;
+  onSaved?: () => void | Promise<void>;
 }
 
 export function OAuthAppRegistrationDialog({
@@ -105,7 +105,7 @@ export function OAuthAppRegistrationDialog({
       toast.success(
         `${integration.display_name} OAuth app ${existing ? "updated" : "registered"}`
       );
-      onSaved?.();
+      await onSaved?.();
       onOpenChange(false);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to save OAuth app");
@@ -493,6 +493,14 @@ export function IntegrationConnectionDialog({
                       </>
                     )}
                   </Button>
+                  <button
+                    type="button"
+                    onClick={openOAuthSetup}
+                    className="w-full text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline transition-colors flex items-center justify-center gap-1.5"
+                  >
+                    <HugeiconsIcon icon={Settings02Icon} className="size-3" />
+                    Edit OAuth App
+                  </button>
                 </div>
               )}
 


### PR DESCRIPTION
Consolidate separate OAuth redirect and manual credential flows into a single IntegrationConnectionDialog. Add dialog return navigation so users return to the connection dialog after configuring an OAuth app.