### PR TITLE
fix: show the correct/actual base url when displaying redirect/callback URL in oauth app connection dialog

### DIFF
--- a/studio/api/app/api/oauth.py
+++ b/studio/api/app/api/oauth.py
@@ -49,7 +49,19 @@ async def _get_oauth_client_credentials(
     return await get_oauth_client_credentials(integration, db)
 
 
+def _oauth_callback_url() -> str:
+    """Return the normalized OAuth callback URL used by the backend."""
+    settings = get_settings()
+    return f"{settings.oauth_callback_base_url.rstrip('/')}/api/oauth/callback"
+
+
 # ── Routes ───────────────────────────────────────────────────────
+
+
+@router.get("/callback-url")
+async def oauth_callback_url() -> dict[str, str]:
+    """Expose the effective OAuth callback URL for frontend display."""
+    return {"callback_url": _oauth_callback_url()}
 
 
 @router.get("/{integration_name}/authorize")
@@ -128,8 +140,7 @@ async def oauth_authorize(
     )
 
     # Build authorize URL from integrations.yaml config
-    settings = get_settings()
-    callback_url = f"{settings.oauth_callback_base_url}/api/oauth/callback"
+    callback_url = _oauth_callback_url()
 
     # Start with integration-defined authorization_params
     params: dict[str, str] = dict(auth.authorization_params)
@@ -218,7 +229,7 @@ async def oauth_callback(
 
     auth = config.auth
     client_id, client_secret = await _get_oauth_client_credentials(integration_name, db)
-    callback_url = f"{settings.oauth_callback_base_url}/api/oauth/callback"
+    callback_url = _oauth_callback_url()
 
     # Build token exchange request from integrations.yaml token_params
     token_data: dict[str, str] = dict(auth.token_params)

--- a/studio/web/src/components/agent/manual-test-view.tsx
+++ b/studio/web/src/components/agent/manual-test-view.tsx
@@ -346,7 +346,7 @@ export default function ManualTestView({
       setVoiceTimeline([]);
       isNearBottomRef.current = true;
 
-      let latestVoiceServerUrl = process.env.NEXT_PUBLIC_VOICE_SERVER_URL?.replace(/\/$/, "") || voiceServerUrl.replace(/\/$/, "");
+      const latestVoiceServerUrl = process.env.NEXT_PUBLIC_VOICE_SERVER_URL?.replace(/\/$/, "") || voiceServerUrl.replace(/\/$/, "");
       attemptedVoiceServerUrlRef.current = latestVoiceServerUrl;
 
       if (!latestVoiceServerUrl) {

--- a/studio/web/src/components/integrations/connection-dialogs.tsx
+++ b/studio/web/src/components/integrations/connection-dialogs.tsx
@@ -67,6 +67,7 @@ export function OAuthAppRegistrationDialog({
   const [clientSecret, setClientSecret] = useState("");
   const [showSecret, setShowSecret] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [callbackUrl, setCallbackUrl] = useState<string>("{server_url}/api/oauth/callback");
 
   useEffect(() => {
     if (!open) return;
@@ -74,6 +75,30 @@ export function OAuthAppRegistrationDialog({
     setClientSecret("");
     setShowSecret(false);
   }, [existing, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    let active = true;
+
+    api.oauth
+      .getCallbackUrl()
+      .then((res) => {
+        if (!active) return;
+        setCallbackUrl(res.callback_url || "{server_url}/api/oauth/callback");
+      })
+      .catch(() => {
+        if (!active) return;
+        if (typeof window !== "undefined") {
+          setCallbackUrl(`${window.location.origin}/api/oauth/callback`);
+          return;
+        }
+        setCallbackUrl("{server_url}/api/oauth/callback");
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [open]);
 
   const handleSave = async () => {
     if (!integration) return;
@@ -137,7 +162,7 @@ export function OAuthAppRegistrationDialog({
             <p className="text-[10px] text-muted-foreground leading-relaxed">
               Create an OAuth app in your <span className="font-medium text-foreground">{integration.display_name}</span>{" "}
               developer portal, set the callback or redirect URL to{" "}
-              <span className="font-mono text-foreground">{`{server_url}/api/oauth/callback`}</span>, then paste the{" "}
+              <span className="font-mono text-foreground">{callbackUrl}</span>, then paste the{" "}
               <span className="font-medium text-foreground">Client ID</span> and{" "}
               <span className="font-medium text-foreground">Client Secret</span> below.
             </p>

--- a/studio/web/src/lib/api/client.ts
+++ b/studio/web/src/lib/api/client.ts
@@ -731,6 +731,8 @@ export const api = {
 
   // OAuth
   oauth: {
+    getCallbackUrl: () =>
+      apiFetch<OAuthCallbackConfig>("/oauth/callback-url"),
     authorize: (skillName: string, agentId: string) =>
       apiFetch<{ authorize_url: string }>(
         `/oauth/${skillName}/authorize?agent_id=${agentId}&origin=${encodeURIComponent(window.location.origin)}`
@@ -1177,6 +1179,10 @@ export interface OAuthAppCreate {
   client_id: string;
   client_secret: string;
   enabled?: boolean;
+}
+
+export interface OAuthCallbackConfig {
+  callback_url: string;
 }
 
 // ── Integration Summary Type ─────────────────────────────────────


### PR DESCRIPTION
### What changed

1. Backend now exposes the effective callback URL:

   - Added `GET /api/oauth/callback-url` in `studio/api/app/api/oauth.py:61`
   - Added shared helper to compute it from `oauth_callback_base_url`: `studio/api/app/api/oauth.py:52`

2. OAuth flow internals now use the same helper (single source of truth):

   - `studio/api/app/api/oauth.py:143`
   - `studio/api/app/api/oauth.py:232`

3. Frontend dialog now fetches and displays that backend URL:

   - Added client method `api.oauth.getCallbackUrl()`: `studio/web/src/lib/api/client.ts:734`
   - Added type: `studio/web/src/lib/api/client.ts:1184`
   - Replaced hardcoded `{server_url}/api/oauth/callback` in dialog: `studio/web/src/components/integrations/connection-dialogs.tsx:162` (fetch logic at `studio/web/src/components/integrations/connection-dialogs.tsx:79`)